### PR TITLE
Added diamond chestplate refund

### DIFF
--- a/book/2.json
+++ b/book/2.json
@@ -25,6 +25,8 @@
     {"score":{"name":"UHC","objective":"uhcGlow"},"color":"gray"},
     {"text":"min ","color":"gray"},
     {"text":"+","color":"dark_green","hoverEvent":{"action":"show_text","value":"+10 minutes"},"clickEvent":{"action":"run_command","value":"/trigger uhcOpt set 105"}},
+    {"text":"\nDiamond chestplate ","color":"dark_gray"},
+    {"storage":"uhc_pack:text","nbt":"Icon.DiamondChestplate","interpret":true,"hoverEvent":{"action":"show_text","value":"Click to toggle between enabled and disabled"},"clickEvent":{"action":"run_command","value":"/trigger uhcOpt set 115"}},
     {"text":"\nStrong potions ","color":"dark_gray"},
     {"storage":"uhc_pack:text","nbt":"Icon.Potion","interpret":true,"hoverEvent":{"action":"show_text","value":"Click to toggle between enabled and disabled"},"clickEvent":{"action":"run_command","value":"/trigger uhcOpt set 109"}},
     {"text":"\nSuspicious stew ","color":"dark_gray"},

--- a/data/uhc_pack/advancements/running/obtain_diamond_chestplate.json
+++ b/data/uhc_pack/advancements/running/obtain_diamond_chestplate.json
@@ -1,0 +1,17 @@
+{
+  "criteria": {
+    "wearing": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:diamond_chestplate"
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "uhc_pack:running/diamond_chestplate/on_obtain"
+  }
+}

--- a/data/uhc_pack/functions/create_scoreboards.mcfunction
+++ b/data/uhc_pack/functions/create_scoreboards.mcfunction
@@ -11,6 +11,7 @@ scoreboard objectives add uhcEter dummy
 scoreboard objectives add uhcGlow dummy
 scoreboard objectives add uhcEnabled dummy
 scoreboard objectives add uhcPotion dummy
+scoreboard objectives add uhcDiaChest dummy
 
 # Lobby scoreboards
 scoreboard objectives add uhcOpt trigger

--- a/data/uhc_pack/functions/lobby/reset_options.mcfunction
+++ b/data/uhc_pack/functions/lobby/reset_options.mcfunction
@@ -10,6 +10,7 @@ scoreboard players set UHC uhcEter 70
 scoreboard players set UHC uhcGlow 80
 scoreboard players set UHCShrink uhcEnabled 1
 scoreboard players set UHCMM uhcEnabled 1
+scoreboard players set UHCDiaChest uhcEnabled 1
 scoreboard players set UHCEter uhcEnabled 1
 scoreboard players set UHCGlow uhcEnabled 1
 scoreboard players set UHCPotion uhcEnabled 1
@@ -23,6 +24,7 @@ scoreboard players set UHCNightVision uhcEnabled 0
 
 data modify storage uhc_pack:text Icon.Shrink set from storage uhc_pack:text Icon.Enabled
 data modify storage uhc_pack:text Icon.Marker set from storage uhc_pack:text Icon.Enabled
+data modify storage uhc_pack:text Icon.DiamondChestplate set from storage uhc_pack:text Icon.Enabled
 data modify storage uhc_pack:text Icon.Eternal set from storage uhc_pack:text Icon.Enabled
 data modify storage uhc_pack:text Icon.Glow set from storage uhc_pack:text Icon.Enabled
 data modify storage uhc_pack:text Icon.Potion set from storage uhc_pack:text Icon.Enabled

--- a/data/uhc_pack/functions/lobby/update_options.mcfunction
+++ b/data/uhc_pack/functions/lobby/update_options.mcfunction
@@ -185,6 +185,13 @@ execute if score UHCNightVision uhcEnabled matches 0 run data modify storage uhc
 execute if score @s[tag=admin] uhcOpt matches 114 if score UHCNightVision uhcEnabled matches 1 run tellraw @a [{"text":"UHC","color":"light_purple"},{"text":" \u2503 ","color":"reset"},{"text":"Options","color":"gray"},{"text":" \u2503 ","color":"reset"},{"text":"Night vision","color":"aqua"},{"text":" is ","color":"reset"},{"text":"Enabled","color":"dark_green"}]
 execute if score @s[tag=admin] uhcOpt matches 114 if score UHCNightVision uhcEnabled matches 0 run tellraw @a [{"text":"UHC","color":"light_purple"},{"text":" \u2503 ","color":"reset"},{"text":"Options","color":"gray"},{"text":" \u2503 ","color":"reset"},{"text":"Night vision","color":"aqua"},{"text":" is ","color":"reset"},{"text":"Disabled","color":"red"}]
 
+# 115 - Toggle Diamond chestlpates
+execute if score @s[tag=admin] uhcOpt matches 115 run execute store success score UHCDiamondChestplate uhcEnabled run execute if score UHCDiamondChestplate uhcEnabled matches 0
+execute if score UHCDiamondChestplate uhcEnabled matches 1 run data modify storage uhc_pack:text Icon.DiamondChestplate set from storage uhc_pack:text Icon.Enabled
+execute if score UHCDiamondChestplate uhcEnabled matches 0 run data modify storage uhc_pack:text Icon.DiamondChestplate set from storage uhc_pack:text Icon.Disabled
+execute if score @s[tag=admin] uhcOpt matches 115 if score UHCDiamondChestplate uhcEnabled matches 1 run tellraw @a [{"text":"UHC","color":"light_purple"},{"text":" \u2503 ","color":"reset"},{"text":"Options","color":"gray"},{"text":" \u2503 ","color":"reset"},{"text":"Diamond chestplates","color":"aqua"},{"text":" are ","color":"reset"},{"text":"Enabled","color":"dark_green"}]
+execute if score @s[tag=admin] uhcOpt matches 115 if score UHCDiamondChestplate uhcEnabled matches 0 run tellraw @a [{"text":"UHC","color":"light_purple"},{"text":" \u2503 ","color":"reset"},{"text":"Options","color":"gray"},{"text":" \u2503 ","color":"reset"},{"text":"Diamond chestplates","color":"aqua"},{"text":" are ","color":"reset"},{"text":"Disabled","color":"red"}]
+
 # Handle sound effects and permission errors
 execute if score @s[tag=!admin] uhcOpt matches 17.. run tellraw @s [{"text":"UHC","color":"light_purple"},{"text":" \u2503 ","color":"reset"},{"text":"Options","color":"gray"},{"text":" \u2503 Sorry, only ","color":"reset"},{"text":"UHC Admins","color":"gold"},{"text":" can perform that action","color":"reset"}]
 execute if score @s uhcOpt matches 3..16 if score UHCJoining uhcEnabled matches 0 run tellraw @s [{"text":"UHC","color":"light_purple"},{"text":" \u2503 ","color":"reset"},{"text":"Options","color":"gray"},{"text":" \u2503 ","color":"reset"},{"text":"Sorry, teams are now locked","color":"reset"}]
@@ -194,4 +201,3 @@ execute if entity @s[tag=admin] if score @s uhcOpt matches 17.. unless score @s 
 
 # Finally, reset the book for everyone so that the scores are updated
 execute as @a run function uhc_pack:lobby/reset_book
-

--- a/data/uhc_pack/functions/lobby/update_options.mcfunction
+++ b/data/uhc_pack/functions/lobby/update_options.mcfunction
@@ -185,7 +185,7 @@ execute if score UHCNightVision uhcEnabled matches 0 run data modify storage uhc
 execute if score @s[tag=admin] uhcOpt matches 114 if score UHCNightVision uhcEnabled matches 1 run tellraw @a [{"text":"UHC","color":"light_purple"},{"text":" \u2503 ","color":"reset"},{"text":"Options","color":"gray"},{"text":" \u2503 ","color":"reset"},{"text":"Night vision","color":"aqua"},{"text":" is ","color":"reset"},{"text":"Enabled","color":"dark_green"}]
 execute if score @s[tag=admin] uhcOpt matches 114 if score UHCNightVision uhcEnabled matches 0 run tellraw @a [{"text":"UHC","color":"light_purple"},{"text":" \u2503 ","color":"reset"},{"text":"Options","color":"gray"},{"text":" \u2503 ","color":"reset"},{"text":"Night vision","color":"aqua"},{"text":" is ","color":"reset"},{"text":"Disabled","color":"red"}]
 
-# 115 - Toggle Diamond chestlpates
+# 115 - Toggle Diamond chestplates
 execute if score @s[tag=admin] uhcOpt matches 115 run execute store success score UHCDiamondChestplate uhcEnabled run execute if score UHCDiamondChestplate uhcEnabled matches 0
 execute if score UHCDiamondChestplate uhcEnabled matches 1 run data modify storage uhc_pack:text Icon.DiamondChestplate set from storage uhc_pack:text Icon.Enabled
 execute if score UHCDiamondChestplate uhcEnabled matches 0 run data modify storage uhc_pack:text Icon.DiamondChestplate set from storage uhc_pack:text Icon.Disabled

--- a/data/uhc_pack/functions/running/diamond_chestplate/cleanup.mcfunction
+++ b/data/uhc_pack/functions/running/diamond_chestplate/cleanup.mcfunction
@@ -1,4 +1,6 @@
-clear @s minecraft:diamond_chestplate
-give @s minecraft:diamond 8
+# This will set the score on the scoreboard to 1, but only if the clear command worked.
+# Fixes a race condition which could occur if the player throws out the chestplate the moment they get it.
+execute store success score @s uhcDiaChest run clear @s minecraft:diamond_chestplate
+execute if score @s uhcDiaChest matches 1 run give @s minecraft:diamond 8
 
 scoreboard players set @s uhcDiaChest 0

--- a/data/uhc_pack/functions/running/diamond_chestplate/cleanup.mcfunction
+++ b/data/uhc_pack/functions/running/diamond_chestplate/cleanup.mcfunction
@@ -1,6 +1,6 @@
 # This will set the score on the scoreboard to 1, but only if the clear command worked.
 # Fixes a race condition which could occur if the player throws out the chestplate the moment they get it.
 execute store success score @s uhcDiaChest run clear @s minecraft:diamond_chestplate
-execute if score @s uhcDiaChest matches 1 run give @s minecraft:diamond 8
 
-scoreboard players set @s uhcDiaChest 0
+# Only refund if the clear command worked!
+execute as @s if score @s uhcDiaChest matches 1 run function uhc_pack:running/diamond_chestplate/refund

--- a/data/uhc_pack/functions/running/diamond_chestplate/cleanup.mcfunction
+++ b/data/uhc_pack/functions/running/diamond_chestplate/cleanup.mcfunction
@@ -1,0 +1,4 @@
+clear @s minecraft:diamond_chestplate
+give @s minecraft:diamond 8
+
+scoreboard players set @s uhcDiaChest 0

--- a/data/uhc_pack/functions/running/diamond_chestplate/on_obtain.mcfunction
+++ b/data/uhc_pack/functions/running/diamond_chestplate/on_obtain.mcfunction
@@ -1,0 +1,5 @@
+advancement revoke @s only uhc_pack:running/obtain_diamond_chestplate
+
+# Mark the player who received the chestplate on a scoreboard.
+# This means cleanup can be handled the tick after, which eliminates desync issues
+execute if score UHCDiamondChestplate uhcEnabled matches 0 run scoreboard players set @s uhcDiaChest 1

--- a/data/uhc_pack/functions/running/diamond_chestplate/refund.mcfunction
+++ b/data/uhc_pack/functions/running/diamond_chestplate/refund.mcfunction
@@ -1,6 +1,6 @@
 give @s minecraft:diamond 8
 
 tellraw @s [{"text":"UHC","color":"light_purple"},{"text":" \u2503 ","color":"reset"},{"text":"Diamond chestplates","color":"gray"},{"text":" \u2503 ","color":"reset"},{"text":"Disabled","color":"red"}]
-playsound minecraft:entity.item.break player @s ~ ~ ~
+execute at @s run playsound minecraft:entity.item.break player @s ~ ~ ~
 
 scoreboard players set @s uhcDiaChest 0

--- a/data/uhc_pack/functions/running/diamond_chestplate/refund.mcfunction
+++ b/data/uhc_pack/functions/running/diamond_chestplate/refund.mcfunction
@@ -1,0 +1,6 @@
+give @s minecraft:diamond 8
+
+tellraw @s [{"text":"UHC","color":"light_purple"},{"text":" \u2503 ","color":"reset"},{"text":"Diamond chestplates","color":"gray"},{"text":" \u2503 ","color":"reset"},{"text":"Disabled","color":"red"}]
+playsound minecraft:entity.item.break player @s ~ ~ ~
+
+scoreboard players set @s uhcDiaChest 0

--- a/data/uhc_pack/functions/running/tick.mcfunction
+++ b/data/uhc_pack/functions/running/tick.mcfunction
@@ -9,3 +9,5 @@ execute as @a[gamemode=spectator,tag=!spectator,scores={uhcATime=1..}] run funct
 execute if score UHC uhcTick matches 1200 run scoreboard players add UHC uhcMin 1
 execute if score UHC uhcTick matches 1200.. run scoreboard players set UHC uhcTick 0
 execute if score UHC uhcTick matches 0 run function #uhc_pack:minute
+
+execute as @a[scores={uhcDiaChest=1..}] run function uhc_pack:running/diamond_chestplate/cleanup


### PR DESCRIPTION
When diamond chestplates are not allowed during the game, whenever a chestplate lands in someone's inventory, this chestplate gets converted back into its ingredients.
This solves issue #8.

This is the most basic solution for it, I'm sure there's small improvements to be made. For example, it might be neat to filter on armor slots, in case a mob drops an enchanted piece of armor (rare case, obviously) which might be useful to disenchant and get books that way.