### PR TITLE
Fix the worldborder in the nether for Spigot/Paper

### DIFF
--- a/data/uhc_pack/functions/running/border_shrinking/activate.mcfunction
+++ b/data/uhc_pack/functions/running/border_shrinking/activate.mcfunction
@@ -32,6 +32,37 @@ execute if score UHC uhcSBSize matches 496 if score UHC uhcSBDur matches 40 run 
 execute if score UHC uhcSBSize matches 496 if score UHC uhcSBDur matches 60 run worldborder set 496 3600
 execute if score UHC uhcSBSize matches 496 if score UHC uhcSBDur matches 80 run worldborder set 496 4800
 execute if score UHC uhcSBSize matches 496 if score UHC uhcSBDur matches 100 run worldborder set 496 6000
+# Fix for Spigot/Paper as world border is dimension specific. This is a noop on Vanilla
+execute if score UHC uhcSBSize matches 16 if score UHC uhcSBDur matches 20 in minecraft:the_nether run worldborder set 16 1200
+execute if score UHC uhcSBSize matches 16 if score UHC uhcSBDur matches 40 in minecraft:the_nether run worldborder set 16 2400
+execute if score UHC uhcSBSize matches 16 if score UHC uhcSBDur matches 60 in minecraft:the_nether run worldborder set 16 3600
+execute if score UHC uhcSBSize matches 16 if score UHC uhcSBDur matches 80 in minecraft:the_nether run worldborder set 16 4800
+execute if score UHC uhcSBSize matches 16 if score UHC uhcSBDur matches 100 in minecraft:the_nether run worldborder set 16 6000
+execute if score UHC uhcSBSize matches 112 if score UHC uhcSBDur matches 20 in minecraft:the_nether run worldborder set 112 1200
+execute if score UHC uhcSBSize matches 112 if score UHC uhcSBDur matches 40 in minecraft:the_nether run worldborder set 112 2400
+execute if score UHC uhcSBSize matches 112 if score UHC uhcSBDur matches 60 in minecraft:the_nether run worldborder set 112 3600
+execute if score UHC uhcSBSize matches 112 if score UHC uhcSBDur matches 80 in minecraft:the_nether run worldborder set 112 4800
+execute if score UHC uhcSBSize matches 112 if score UHC uhcSBDur matches 100 in minecraft:the_nether run worldborder set 112 6000
+execute if score UHC uhcSBSize matches 208 if score UHC uhcSBDur matches 20 in minecraft:the_nether run worldborder set 208 1200
+execute if score UHC uhcSBSize matches 208 if score UHC uhcSBDur matches 40 in minecraft:the_nether run worldborder set 208 2400
+execute if score UHC uhcSBSize matches 208 if score UHC uhcSBDur matches 60 in minecraft:the_nether run worldborder set 208 3600
+execute if score UHC uhcSBSize matches 208 if score UHC uhcSBDur matches 80 in minecraft:the_nether run worldborder set 208 4800
+execute if score UHC uhcSBSize matches 208 if score UHC uhcSBDur matches 100 in minecraft:the_nether run worldborder set 208 6000
+execute if score UHC uhcSBSize matches 304 if score UHC uhcSBDur matches 20 in minecraft:the_nether run worldborder set 304 1200
+execute if score UHC uhcSBSize matches 304 if score UHC uhcSBDur matches 40 in minecraft:the_nether run worldborder set 304 2400
+execute if score UHC uhcSBSize matches 304 if score UHC uhcSBDur matches 60 in minecraft:the_nether run worldborder set 304 3600
+execute if score UHC uhcSBSize matches 304 if score UHC uhcSBDur matches 80 in minecraft:the_nether run worldborder set 304 4800
+execute if score UHC uhcSBSize matches 304 if score UHC uhcSBDur matches 100 in minecraft:the_nether run worldborder set 304 6000
+execute if score UHC uhcSBSize matches 400 if score UHC uhcSBDur matches 20 in minecraft:the_nether run worldborder set 400 1200
+execute if score UHC uhcSBSize matches 400 if score UHC uhcSBDur matches 40 in minecraft:the_nether run worldborder set 400 2400
+execute if score UHC uhcSBSize matches 400 if score UHC uhcSBDur matches 60 in minecraft:the_nether run worldborder set 400 3600
+execute if score UHC uhcSBSize matches 400 if score UHC uhcSBDur matches 80 in minecraft:the_nether run worldborder set 400 4800
+execute if score UHC uhcSBSize matches 400 if score UHC uhcSBDur matches 100 in minecraft:the_nether run worldborder set 400 6000
+execute if score UHC uhcSBSize matches 496 if score UHC uhcSBDur matches 20 in minecraft:the_nether run worldborder set 496 1200
+execute if score UHC uhcSBSize matches 496 if score UHC uhcSBDur matches 40 in minecraft:the_nether run worldborder set 496 2400
+execute if score UHC uhcSBSize matches 496 if score UHC uhcSBDur matches 60 in minecraft:the_nether run worldborder set 496 3600
+execute if score UHC uhcSBSize matches 496 if score UHC uhcSBDur matches 80 in minecraft:the_nether run worldborder set 496 4800
+execute if score UHC uhcSBSize matches 496 if score UHC uhcSBDur matches 100 in minecraft:the_nether run worldborder set 496 6000
 
 tellraw @a [{"text":""},{"text":"UHC","color":"light_purple"},{"text":" \u2503 "},{"text":"Shrinking","color":"gray"},{"text":" \u2503 "},{"text":"Activated","color":"gold"}]
 execute as @a at @s run playsound minecraft:entity.elder_guardian.curse player @s ~ ~ ~ 1 0

--- a/data/uhc_pack/functions/setup.mcfunction
+++ b/data/uhc_pack/functions/setup.mcfunction
@@ -2,12 +2,20 @@
 # Set up the UHC lobby in the current location
 #
 # Entity: A server operator
-# Location: The center of the UHC around
+# Location: The center of the UHC arena
 #
 
-tellraw @a [{"text":""},{"text":"UHC","color":"light_purple"},{"text":" \u2503 "},{"text":"Setup","color":"gray"},{"text":" \u2503 Setting world spawn to current location"}]
+tellraw @a [{"text":""},{"text":"UHC","color":"light_purple"},{"text":" \u2503 "},{"text":"Setup","color":"gray"},{"text":" \u2503 Setting world spawn to "},{"entity":"@s","nbt":"Pos[0]"},{"text":", "},{"entity":"@s","nbt":"Pos[2]"}]
 setworldspawn ~ 253 ~
+
 worldborder center ~ ~
+# Spigot/Paper fix. worldborder is dimension specific but the center will be different in
+# each dimension, so we need to detect if there is no worldborder in the nether and only
+# execute the fix if that is the case
+worldborder set 3056
+execute in minecraft:the_nether store result score UHCWB uhcPG run worldborder get
+execute unless score UHCWB uhcPG matches 3056 in minecraft:the_nether run function uhc_pack:spigot/nether_worldborder
+scoreboard players reset UHCWB uhcPG
 
 tellraw @a [{"text":""},{"text":"UHC","color":"light_purple"},{"text":" \u2503 "},{"text":"Setup","color":"gray"},{"text":" \u2503 Generating lobby (may take a few seconds)"}]
 fill ~-12 250 ~-12 ~11 253 ~11 minecraft:barrier hollow

--- a/data/uhc_pack/functions/spigot/nether_worldborder.mcfunction
+++ b/data/uhc_pack/functions/spigot/nether_worldborder.mcfunction
@@ -1,0 +1,20 @@
+#
+# Fix the center of the nether worldborder on Spigot/Paper
+#
+# Entity: A server operator, positioned at the center of the UHC arena
+# Location: In the nether
+#
+
+execute store success score AlreadyLoadedOrigin uhcPG run forceload query 0 0
+forceload add 0 0
+
+summon minecraft:armor_stand 0 251 0 {Tags:[lobby,nethercenter],NoGravity:1b,Small:1b,Invisible:1b}
+
+execute store result storage uhc_pack:dynamic_tp Pos[0] double 0.125 run data get entity @s Pos[0]
+execute store result storage uhc_pack:dynamic_tp Pos[1] double 1 run data get entity @s Pos[1]
+execute store result storage uhc_pack:dynamic_tp Pos[2] double 0.125 run data get entity @s Pos[2]
+
+execute as @e[type=minecraft:armor_stand,tag=nethercenter] run function uhc_pack:spigot/nether_worldborder_set
+
+execute if score AlreadyLoadedOrigin uhcPG matches 0 run forceload remove 0 0
+scoreboard players reset AlreadyLoadedOrigin uhcPG

--- a/data/uhc_pack/functions/spigot/nether_worldborder_set.mcfunction
+++ b/data/uhc_pack/functions/spigot/nether_worldborder_set.mcfunction
@@ -1,0 +1,13 @@
+#
+# Set the center of the nether worldborder to the location of uhc_pack:dynamic_tp Pos
+#
+# Entity: @e[type=minecraft:armor_stand,tag=nethercenter]
+# Location: In the nether
+#
+
+data modify entity @s Pos set from storage uhc_pack:dynamic_tp Pos
+
+tellraw @a [{"text":""},{"text":"UHC","color":"light_purple"},{"text":" \u2503 "},{"text":"Setup","color":"gray"},{"text":" \u2503 Setting nether world border center to "},{"entity":"@s","nbt":"Pos[0]"},{"text":", "},{"entity":"@s","nbt":"Pos[2]"}]
+
+execute at @s run worldborder center ~ ~
+kill @s

--- a/data/uhc_pack/functions/starting/start.mcfunction
+++ b/data/uhc_pack/functions/starting/start.mcfunction
@@ -20,6 +20,13 @@ execute if score UHC uhcBSize matches 1520 run worldborder set 1520
 execute if score UHC uhcBSize matches 2032 run worldborder set 2032
 execute if score UHC uhcBSize matches 2544 run worldborder set 2544
 execute if score UHC uhcBSize matches 3056 run worldborder set 3056
+# Fix for Spigot/Paper as world border is dimension specific. This is a noop on Vanilla
+execute if score UHC uhcBSize matches 496 in minecraft:the_nether run worldborder set 496
+execute if score UHC uhcBSize matches 1008 in minecraft:the_nether run worldborder set 1008
+execute if score UHC uhcBSize matches 1520 in minecraft:the_nether run worldborder set 1520
+execute if score UHC uhcBSize matches 2032 in minecraft:the_nether run worldborder set 2032
+execute if score UHC uhcBSize matches 2544 in minecraft:the_nether run worldborder set 2544
+execute if score UHC uhcBSize matches 3056 in minecraft:the_nether run worldborder set 3056
 
 gamemode survival @a[team=!spectate]
 execute as @a[team=spectate] run function uhc_pack:running/make_player_spectator


### PR DESCRIPTION
The world border is dimension specific in Paper and Spigot, so the
center needs to be set in the nether but not in vanilla

Fixes #49